### PR TITLE
Feat/student variance

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,17 +1,22 @@
 # A simple script to generate a set of students
+import math
 
 from generator.factory import Factory
 from generator.strategy import DemoStrategy
-from generator.constants import DEMO
+from generator.constants import DEMO, ELL_PCT, POV_PCT
 import numpy as np
 
 # Choices
 n = 100000  # Number of students desired
-pov_cost = 0.05  # mean drop for student in poverty
-ell_cost = 0.05  # mean drop for english learners in reading and english
-dis_cost = 0.05  # max possible mean change for a student with a disability
+dis_size = math.sqrt(300)/2  # max possible mean change for a student with a disability
+ell_sigma = math.sqrt(10)    # desired standard deviation of effect of being an English learner
+# drop for english learners in reading and english
+ell_cost = math.sqrt(ell_sigma**2/(ELL_PCT**2 - ELL_PCT**3 + ELL_PCT))
+pov_sigma = math.sqrt(10)    # desired standard deviation of effect of poverty
+# drop for students in poverty in general aptitude
+pov_cost = math.sqrt(pov_sigma**2/(POV_PCT**2 - POV_PCT**3 + POV_PCT))
 
-strat = DemoStrategy(pov_cost, ell_cost, dis_cost)
+strat = DemoStrategy(dis_size, ell_sigma, ell_cost, pov_sigma, pov_cost)
 stud_fact = Factory(n, DEMO, strat)
 stud_fact.print_demos()
 

--- a/generator/constants.py
+++ b/generator/constants.py
@@ -179,3 +179,7 @@ DEMO = {'gender': 0.505, 'race': {'distribution': [0.624, 0.023, 0.23, 0.04, 0.0
 # Once that choice is made, we can use the ethnicity 'code' as an index in ell and poverty to get a 'correct'
 # demographic breakdown for the race of that student, and make additional random number selections to decide on them;
 # it is hoped that this gives is some approximation of intersectionality.
+
+DIS_PCT = sum([x[0]*x[1] for x in zip(DEMO['race']['distribution'], DEMO['race']['disability'])])
+ELL_PCT = sum([x[0]*x[1] for x in zip(DEMO['race']['distribution'], DEMO['race']['ell'])])
+POV_PCT = sum([x[0]*x[1] for x in zip(DEMO['race']['distribution'], DEMO['race']['poverty'])])

--- a/generator/strategy.py
+++ b/generator/strategy.py
@@ -1,3 +1,6 @@
+import math
+
+from .constants import DIS_PCT, ELL_PCT, POV_PCT
 import numpy as np
 
 
@@ -8,6 +11,20 @@ class Strategy:
     But can also be considered to define the interface for more complex
     strategies that inherit from it.
     """
+
+    def __init__(self):
+        # These are used in more complex Strategies
+        self.generic_mu = 0
+        self.generic_sigma = math.sqrt(50)
+        self.english_mu = 0
+        self.english_sigma = math.sqrt(50)
+        self.math_mu = 0
+        self.math_sigma = math.sqrt(50)
+        self.reading_mu = 0
+        self.reading_sigma = math.sqrt(50)
+        self.science_mu = 0
+        self.science_sigma = math.sqrt(50)
+
     def _compute_generic_factor(self, student):
         """
         Defines the strategy for computing a general proficiency scale factor
@@ -15,7 +32,7 @@ class Strategy:
         :param student: A Student object
         :return: A float multiplier.
         """
-        return 1.0
+        return 0.0
 
     def _compute_english_factor(self, student):
         """
@@ -24,7 +41,7 @@ class Strategy:
         :param student: A Student object
         :return: A float multiplier.
         """
-        return 1.0
+        return 0.0
 
     def _compute_math_factor(self, student):
         """
@@ -33,7 +50,7 @@ class Strategy:
         :param student: A Student object
         :return: A float multiplier.
         """
-        return 1.0
+        return 0.0
 
     def _compute_reading_factor(self, student):
         """
@@ -42,7 +59,7 @@ class Strategy:
         :param student: A Student object
         :return: A float multiplier.
         """
-        return 1.0
+        return 0.0
 
     def _compute_science_factor(self, student):
         """
@@ -51,9 +68,9 @@ class Strategy:
         :param student: A Student object
         :return: A float multiplier.
         """
-        return 1.0
+        return 0.0
 
-    def get_proficiency_factors(self, student):
+    def get_proficiency_bonuses(self, student):
         """
         Use the demographics of the Student object to compute proficiency scale factors.
         This is the only function that should be called by the Student, and shouldn't change.
@@ -63,10 +80,10 @@ class Strategy:
         """
         gen_apt = self._compute_generic_factor(student)
         return {
-            "english": gen_apt * self._compute_english_factor(student),
-            "math": gen_apt * self._compute_math_factor(student),
-            "reading": gen_apt * self._compute_reading_factor(student),
-            "science": gen_apt * self._compute_science_factor(student)
+            "english": gen_apt + self._compute_english_factor(student),
+            "math": gen_apt + self._compute_math_factor(student),
+            "reading": gen_apt + self._compute_reading_factor(student),
+            "science": gen_apt + self._compute_science_factor(student)
         }
 
 
@@ -83,9 +100,7 @@ class NoDemoStrategy(Strategy):
         :param student: A Student object
         :return: A float multiplier.
         """
-        mu = 1
-        sigma = 0.05
-        return np.random.normal(mu, sigma)
+        return np.random.normal(self.generic_mu, self.generic_sigma)
 
     def _compute_english_factor(self, student):
         """
@@ -93,9 +108,7 @@ class NoDemoStrategy(Strategy):
         :param student: A Student object
         :return: A float multiplier.
         """
-        mu = 1
-        sigma = 0.05
-        return np.random.normal(mu, sigma)
+        return np.random.normal(self.english_mu, self.english_sigma)
 
     def _compute_math_factor(self, student):
         """
@@ -103,9 +116,7 @@ class NoDemoStrategy(Strategy):
         :param student: A Student object
         :return: A float multiplier.
         """
-        mu = 1
-        sigma = 0.05
-        return np.random.normal(mu, sigma)
+        return np.random.normal(self.math_mu, self.math_sigma)
 
     def _compute_reading_factor(self, student):
         """
@@ -113,9 +124,7 @@ class NoDemoStrategy(Strategy):
         :param student: A Student object
         :return: A float multiplier.
         """
-        mu = 1
-        sigma = 0.05
-        return np.random.normal(mu, sigma)
+        return np.random.normal(self.reading_mu, self.reading_sigma)
 
     def _compute_science_factor(self, student):
         """
@@ -123,67 +132,106 @@ class NoDemoStrategy(Strategy):
         :param student: A Student object
         :return: A float multiplier.
         """
-        mu = 1
-        sigma = 0.05
-        return np.random.normal(mu, sigma)
+        return np.random.normal(self.science_mu, self.science_sigma)
 
 
 class DemoStrategy(Strategy):
     """
     """
 
-    def __init__(self, pov_cost, ell_cost, dis_cost):
-        self.pov_cost = pov_cost
+    def __init__(self, dis_size, ell_sigma, ell_cost, pov_sigma, pov_cost):
+        super().__init__()
+        self.dis_size = dis_size
+        self.desired_ell_sigma = ell_sigma
         self.ell_cost = ell_cost
-        self.dis_cost = dis_cost
+        self.ell_posi = self._compute_positive_ell_effect()
+        self.desired_pov_sigma = pov_sigma
+        self.pov_cost = pov_cost
+        self.pov_posi = self._compute_positive_poverty_effect()
+
+    def _compute_positive_ell_effect(self):
+        """
+        When we presume the negative effect of a demographic and the desired variation
+        of a distribution in which one class gets a uniform negative effect and the other
+        a uniform positive one, and where we want to keep the mean effect at 0, we can
+        compute the necessary positive effect to line things up.
+
+        :return: a real number representing the positive effect
+        """
+        if self.desired_ell_sigma**2 - self.ell_cost**2 * ELL_PCT < 0:
+            raise ValueError("Negative ell effect is too large compared to the desired variance.")
+        return math.sqrt((self.desired_ell_sigma**2 - self.ell_cost**2 * ELL_PCT)/(1 - ELL_PCT))
+
+    def _compute_positive_poverty_effect(self):
+        """
+        When we presume the negative effect of a demographic and the desired variation
+        of a distribution in which one class gets a uniform negative effect and the other
+        a uniform positive one, and where we want to keep the mean effect at 0, we can
+        compute the necessary positive effect to line things up.
+
+        :return: a real number representing the positive effect
+        """
+        if self.desired_pov_sigma**2 - self.pov_cost**2 * POV_PCT < 0:
+            raise ValueError("Negative poverty effect is too large compared to the desired variance.")
+        return math.sqrt((self.desired_pov_sigma**2 - self.pov_cost**2 * POV_PCT)/(1 - POV_PCT))
 
     def _compute_generic_factor(self, student):
         """
         The generic proficiency of a student gives a bonus or penalty to every subject.
-        :param student: A Student object
-        :return: A float multiplier.
+        :param student: a Student object
+        :return: a float bonus
         """
-        mu = 1 - student.poverty * self.pov_cost
-        sigma = 0.05
+        if student.poverty:
+            mu = self.pov_cost
+        else:
+            mu = self.pov_posi
+        sigma = math.sqrt(50 - self.desired_pov_sigma**2)
         return np.random.normal(mu, sigma)
 
     def _compute_english_factor(self, student):
         """
-        The English proficiency of a student gives a bonus or penalty to every subject.
-        :param student: A Student object
-        :return: A float multiplier.
+        The English proficiency of a student gives a bonus or penalty to English RIT scores.
+        :param student: a Student object
+        :return: a float multiplier
         """
-        mu = 1 - student.ell * self.ell_cost + student.disabled * np.random.uniform(-1, 1) * self.dis_cost
-        sigma = 0.05
+        if student.ell:
+            mu = self.ell_cost
+        else:
+            mu = self.ell_posi
+        mu += student.disabled * np.random.uniform(-1, 1) * self.dis_size
+        sigma = math.sqrt(50 - self.desired_ell_sigma**2 - 25*(DIS_PCT**2))
         return np.random.normal(mu, sigma)
 
     def _compute_math_factor(self, student):
         """
-        The Math proficiency of a student gives a bonus or penalty to every subject.
+        The Math proficiency of a student gives a bonus or penalty to math RIT scores.
         :param student: A Student object
-        :return: A float multiplier.
+        :return: a float multiplier
         """
-        mu = 1 + student.disabled * np.random.uniform(-1, 1) * self.dis_cost
-        sigma = 0.05
+        mu = student.disabled * np.random.uniform(-1, 1) * self.dis_size
+        sigma = math.sqrt(50 - 25*(DIS_PCT**2))
         return np.random.normal(mu, sigma)
 
     def _compute_reading_factor(self, student):
         """
-        The reading proficiency of a student gives a bonus or penalty to every subject.
+        The reading proficiency of a student gives a bonus or penalty to reading RIT scores.
         :param student: A Student object
-        :return: A float multiplier.
+        :return: a float multiplier
         """
-        mu = 1 - student.ell * self.ell_cost + student.disabled * np.random.uniform(-1, 1) * self.dis_cost
-        sigma = 0.05
+        if student.ell:
+            mu = self.ell_cost
+        else:
+            mu = self.ell_posi
+        mu += student.disabled * np.random.uniform(-1, 1) * self.dis_size
+        sigma = math.sqrt(50 - self.desired_ell_sigma**2 - 25*(DIS_PCT**2))
         return np.random.normal(mu, sigma)
 
     def _compute_science_factor(self, student):
         """
-        The Science proficiency of a student gives a bonus or penalty to every subject.
+        The Science proficiency of a student gives a bonus or penalty to science RIT scores.
         :param student: A Student object
-        :return: A float multiplier.
+        :return: a float multiplier
         """
-        mu = 1 + student.disabled * np.random.uniform(-1, 1) * self.dis_cost
-        sigma = 0.05
+        mu = student.disabled * np.random.uniform(-1, 1) * self.dis_size
+        sigma = math.sqrt(50 - 25*(DIS_PCT**2))
         return np.random.normal(mu, sigma)
-


### PR DESCRIPTION
Here is my attempt at a rework of score generation with the goal of leaving variance somewhat alone.

The gist of my thought process is as follows:
- We can assume that the overall effect on the average scores for various causes is 0, treating them as variance machines.
- The total variance is known, and is caused by general aptitude, subject aptitude, and statistical noise.
- These effects are independent, so that the sum of the variances is the total (known) variance.
- The variance not caused by noise is half general aptitude and half subject.
- poverty lowers general aptitude and lack of raises it by such factors that the overall mean effect is zero but RIT score variance is 10.
- EL status lowers subject aptitudes in English and reading, while native speakers get a smaller positive effect.  Like with poverty, the overall mean effect is zero but 10 variance is contributed to the mean score.
- disability is hard and confusing.  I just increased the variance for that population while decreasing subject aptitude for each subject, such that the total variance across Oregon was 50.
- This generates bonuses for each subject with means of 0 and variances of 50; adding the general aptitude bonuses to each subject raises the variance to 100.
- noise is the cause of the rest of the variance when generating an initial score for a student.
- all effects are dropped by a factor of 3 when looking at change, causing the variance of the effects to drop by a factor of 9.

There are so many huge, flawed assumptions in that data, but it gets us not horrible data with what should be an appropriate amount of variance.  I'm happy to hear any feedback.